### PR TITLE
Bug/metadata lower chars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ locals {
     apiVersion = "v1"
     kind       = "Secret"
     metadata = {
-      name        = lower(try(var.cluster.secret_name, local.cluster_name))
+      name        = try(var.cluster.secret_name, lower(local.cluster_name))
       namespace   = try(var.cluster.secret_namespace, "argocd")
       annotations = local.argocd_annotations
       labels      = local.argocd_labels

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ locals {
     apiVersion = "v1"
     kind       = "Secret"
     metadata = {
-      name        = try(lower(var.cluster.secret_name, local.cluster_name))
+      name        = lower(try(var.cluster.secret_name, local.cluster_name))
       namespace   = try(var.cluster.secret_namespace, "argocd")
       annotations = local.argocd_annotations
       labels      = local.argocd_labels

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ locals {
     apiVersion = "v1"
     kind       = "Secret"
     metadata = {
-      name        = try(var.cluster.secret_name, local.cluster_name)
+      name        = try(lower(var.cluster.secret_name, local.cluster_name))
       namespace   = try(var.cluster.secret_namespace, "argocd")
       annotations = local.argocd_annotations
       labels      = local.argocd_labels


### PR DESCRIPTION
Is the EKS cluster has Upper chars secret was not created with error:

```
 Error: metadata.0.name a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
│
│   with module.gitops_bridge_bootstrap.kubernetes_secret_v1.cluster[0],
│   on .terraform/modules/gitops_bridge_bootstrap/main.tf line 127, in resource "kubernetes_secret_v1" "cluster":
│  127:     name        = local.argocd.metadata.name
```
Fixing the issue by using the lower function in the clusters name